### PR TITLE
Add check for single-line JSON Objects

### DIFF
--- a/src/detectCode.js
+++ b/src/detectCode.js
@@ -40,6 +40,7 @@ const nonHtmlIndicators = [
   '\\\\[\'"ntr0\\\\]', // common escape sequences
   `<\\?[^>]*\\?>`, // PHP
   `<%[^>]*%>`, // ERB (Rails)
+  `"${varName}"\\s*:`, // JSON property
 ];
 
 const htmlIndicators = [

--- a/src/detectCode.js
+++ b/src/detectCode.js
@@ -40,7 +40,7 @@ const nonHtmlIndicators = [
   '\\\\[\'"ntr0\\\\]', // common escape sequences
   `<\\?[^>]*\\?>`, // PHP
   `<%[^>]*%>`, // ERB (Rails)
-  `"${varName}"\\s*:`, // JSON property
+  `^\\s*{\\s*"${varName}"\\s*:`, // single-line JSON property
 ];
 
 const htmlIndicators = [

--- a/src/test/detectCode.test.js
+++ b/src/test/detectCode.test.js
@@ -98,6 +98,7 @@ const withUnformattedCode = [
   '<? hello erb ?>',
   '<% hello php %>',
   'some other stuff\n\n[quote="David_Bowie, post:8, topic:1120"]\nquoted text\n[/quote]\n\ncode overHere()',
+  '{"a": 1}'
 ];
 
 const withBareHTML = [


### PR DESCRIPTION
I've just installed this component to our [Node-RED Discourse instance](https://discourse.nodered.org).

In our world, users frequently post JSON strings as a way to share their Node-RED flow configuration. This plugin properly detects well-formatted JSON (due to the check for a `{` or `}` on a line by itself). But it doesn't detect compact JSON - all on a single line.

This PR adds a simple check for strings like `{ "foo":` as an indicator of a single-line JSON object.

I don't think that will trip anything up as a false positive.