### PR TITLE
FIX: strip uploads markdown

### DIFF
--- a/__test__/fixtures.js
+++ b/__test__/fixtures.js
@@ -50,6 +50,8 @@ export const noCode = [
   "That's Japanese. :stuck_out_tongue:\n\nFunny bug though.",
   "That's Japanese. :???:\n\nFunny bug though.",
   "That's Japanese. :!:\n\nFunny bug though.",
+  "Please read the following attachment\n\n[certificate.pdf|attachment](upload://4KTUbKTzhNHwhehPczlNZvxxlaZ.pdf) (54,1 Ko)",
+  "Look at this amazing picture!\n\n![image|666x500](upload://wLp2YD6Tqxxh0YmRvpwG5mqQhOM.jpeg)",
 ];
 
 export const withUnformattedCode = [

--- a/javascripts/unformatted_code_detector/lib/strip-ignored-content.js.es6
+++ b/javascripts/unformatted_code_detector/lib/strip-ignored-content.js.es6
@@ -1,30 +1,33 @@
+const ignoredContents = [
+  // PROPERLY FORMATTED CODE
+  // - backtick/tilde-fenced block
+  /(^([`~])\2{2,})[^`~\r\n]*\r?\n[\s\S]*?\r?\n\1\2*\s*(?:\r?\n|$)/gm,
+  // - indented block (lack of `m` flag is intentional, `^` must match beginning of input, not line)
+  /(?:^|(?:\r?\n{2,}))\s*(?:(?: {4}|\t).*(?:\r?\n|$))/g,
+  // - inline backticks (must come after fenced code blocks)
+  /`[^`\r\n]+`/g,
+
+  // BBCODE TAGS
+  /\[([a-z]+).*?\][\s\S]*?\[\/\1\]/gim,
+
+  // UPLOADS
+  /!?\[[^\]]+?\]\(upload:\/\/[\w.]+?\)(?: \([\d,.]+ \w+\))?/g,
+
+  // URLs
+  // - parens/underscores (for Wikipedia-style URLs)
+  /https?:\/\/(_\([^() \r\n\t]+\)|[^() \r\n\t])+/g,
+
+  // EMOJIS
+  // - descriptive style (e.g. :wink: or :stuck_out_tongue:)
+  /:[a-z_+-][a-z_0-9+-]*:/g,
+  // - emoticon style (eg. ;) or :-P)
+  /:D|:-D|:\)|:-\)|;\)|;-\)|:\(|:-\(|:o|:-o|:\?|:-\?|:\?\?\?:|8\)|8-\)|:x|:-x|:P|:-P|:!:|:\?:|:\||:-\||^_^|^__^|:'\(|:'-\(|:-'\(|:p|:O|:-O|:\/|;P|;-P|:\$|:-\$/g,
+
+  // MISC
+  // - copy/trademark/registered
+  /\((?:c|tm|r)\)/gi,
+];
+
 export const stripIgnoredContent = (content) => {
-  const ignoredContents = [
-    // properly formatted code
-    /(^([`~])\2{2,})[^`~\r\n]*\r?\n[\s\S]*?\r?\n\1\2*\s*(?:\r?\n|$)/gm, // backtick-/tilde-fenced block
-    /(?:^|(?:\r?\n{2,}))\s*(?:(?: {4}|\t).*(?:\r?\n|$))/g, // indented block
-    // lack of `m` flag is intentional (`^` must match beginning of input, not line)
-
-    /`[^`\r\n]+`/g, // inline backticks (must come after fenced code blocks)
-
-    /\[([a-z]+).*?\][\s\S]*?\[\/\1\]/gim, // BBCode tags
-
-    // URLs
-    /https?:\/\/(_\([^() \r\n\t]+\)|[^() \r\n\t])+/g, // parens/underscores
-    // for Wikipedia-style URLs
-
-    // emojis
-    /:[a-z_+-][a-z_0-9+-]*:/g, // descriptive style, e.g. :wink:, :stuck_out_tongue:
-    /:D|:-D|:\)|:-\)|;\)|;-\)|:\(|:-\(|:o|:-o|:\?|:-\?|:\?\?\?:|8\)|8-\)|:x|:-x|:P|:-P|:!:|:\?:|:\||:-\||^_^|^__^|:'\(|:'-\(|:-'\(|:p|:O|:-O|:\/|;P|;-P|:\$|:-\$/g, // emoticon style, e.g. ;), :-P
-    // per https://github.com/discourse/discourse/blob/dc6b547ed89f652b5406489d76140b76cf8e0d1d/script/import_scripts/phpbb3/support/smiley_processor.rb#L36-L63 and https://github.com/discourse/discourse/blob/0eeedf307a8f2a8e1ccd5b24dafbf5a7fd20e51e/lib/emoji/db.json#L7015-L7042
-
-    // misc
-    /\((?:c|tm|r)\)/gi, // copy/trademark/registered
-  ];
-
-  const strippedContent = ignoredContents.reduce((str, ignoredContent) => {
-    return str.replace(ignoredContent, "");
-  }, content);
-
-  return strippedContent;
+  return ignoredContents.reduce((s, ignored) => s.replace(ignored, ""), content);
 };


### PR DESCRIPTION
Discourse uses a custom markdown for uploads:

`![image|375x500](upload://fBMk3zZzIsr04FAWeH9U8q9N8z7.jpeg)` for images
`[certificate.pdf|attachment](upload://44TUbKTThNHHhehPczlNRvxxlaZ.pdf) (34,5 Ko)` for attachments

We can safely strip them down before doing the code detection.

Also extracted the `ignoredContents` out of the `stripIgnoredContent` method and reformatted the comments.