### PR TITLE
Add optional regex arguments for custom code-match patterns.

### DIFF
--- a/about.json
+++ b/about.json
@@ -4,7 +4,7 @@
   "license_url": "https://github.com/discourse/unformatted-code-detector/blob/main/LICENSE",
   "about_url": "https://meta.discourse.org/t/unformatted-code-detector-theme-component/112773",
   "authors": "Lionel Rowe",
-  "theme_version": "0.11",
+  "theme_version": "0.11.1",
   "minimum_discourse_version": null,
   "maximum_discourse_version": null,
   "learn_more": "https://meta.discourse.org/t/beginners-guide-to-using-discourse-themes/91966"

--- a/javascripts/unformatted-code-detector/core/code-energy.js
+++ b/javascripts/unformatted-code-detector/core/code-energy.js
@@ -71,7 +71,9 @@ const _codeEnergyIndicators = {
   // multiple-character matches
   [CodeEnergyLevels.Complex]: {
     get indicators() {
-      return [nonHtmlIndicators, settings.include_html && htmlIndicators]
+      return [nonHtmlIndicators,
+              settings.include_extra_patterns && settings.custom_regex_strings.split("|"),
+              settings.include_html && htmlIndicators]
         .filter(Boolean)
         .flat();
     },

--- a/settings.yml
+++ b/settings.yml
@@ -25,6 +25,15 @@ max_post_length_to_check:
   min: -1
   description:
     en: Maximum post length to check (number of characters). -1 = no maximum.
+custom_regex_strings:
+  default: ^#!
+  type: list
+  description:
+    en: "Additional regex match strings to detect possible code fragments. CAUTION: These strings are evaluated directly with no syntax checking."
+include_extra_patterns:
+  default: false
+  description:
+    en: Enable custom regex pattern string matching.
 include_html:
   default: true
   description:


### PR DESCRIPTION
Optional patterns may be disabled by "Use extra regex patterns" set to false (default).
Initial list contains definition for 'shebang' (interpreter directive) - common first-line in Unix-style scripts.

Version bumped to 0.11.1 (edit as needed)