### PR TITLE
FIX: Deprecation and CookText not rendering

### DIFF
--- a/javascripts/discourse/components/modal/ucd-warning.hbs
+++ b/javascripts/discourse/components/modal/ucd-warning.hbs
@@ -1,7 +1,7 @@
 <DModal
   @closeModal={{this.closeModal}}
   class="modal-ucd-warning"
-  @title={{modal-ucd-title}}
+  @title={{(modal-ucd-title)}}
   @inline={{@inline}}
 >
   <Ucd::Warning @onClose={{this.closeModal}} />

--- a/javascripts/discourse/components/ucd-warning.hbs
+++ b/javascripts/discourse/components/ucd-warning.hbs
@@ -1,4 +1,4 @@
-{{cook-text (theme-i18n "warning_modal.content")}}
+<CookText @rawText={{theme-i18n "warning_modal.content"}} />
 <label for="ucd_do-not-show-again" class="checkbox-label">
   <Input
     @type="checkbox"


### PR DESCRIPTION
**This PR fixes two issues:**
1. Since the core change (https://github.com/discourse/discourse/commit/61571bee43eae88755b5e258e96d03c146f9d2cb) of the CookText component to a Glimmer component, positional arguments are no longer supported, causing the modal's cooked text to break. This PR  updates the component usage to angle bracket syntax with named arguments to fix the issue. Since this syntax works on older versions as well, no discourse-compatibility file update is necessary.
2. Resolves the following [deprecation warning](https://deprecations.emberjs.com/v3.x/#toc_argument-less-helper-paren-less-invocation)