### PR TITLE
UX: add missing button class

### DIFF
--- a/javascripts/discourse/components/ucd-warning.gjs
+++ b/javascripts/discourse/components/ucd-warning.gjs
@@ -55,6 +55,7 @@ export default class UcdWarning extends Component {
         @label={{themePrefix "warning_modal.fix_post"}}
       />
       <DButton
+        class="btn-default"
         @action={{this.ignoreAndProceed}}
         @label={{themePrefix "warning_modal.ignore_and_post_anyway"}}
       />


### PR DESCRIPTION
Adds a missing btn-default class so button styles apply properly 

Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/d9076bba-3efd-4fb2-ab1b-3e95d2075aac" />


After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/1684e0b1-4981-4a78-af8d-cab86e22b91d" />
