### PR TITLE
FIX: Stop the BBCode rule backtracking on unclosed tags

### DIFF
--- a/javascripts/discourse/core/strip-ignored-content.js
+++ b/javascripts/discourse/core/strip-ignored-content.js
@@ -6,7 +6,7 @@ const ignoredContents = [
 
   /`[^`\n]+`/g, // inline backticks (must come after fenced code blocks)
 
-  /\[([a-z]+).*?\][\s\S]*?\[\/\1\]/gim, // BBCode tags
+  /\[([a-z]+)[^\]\n]*\][\s\S]*?\[\/\1\]/gi, // BBCode tags
 
   // URLs
   /https?:\/\/(_\([^() \n\t]+\)|[^() \n\t])+/g, // parens/underscores

--- a/test/unit/strip-ignored-content-test.js
+++ b/test/unit/strip-ignored-content-test.js
@@ -1,0 +1,49 @@
+import { module, test } from "qunit";
+import { stripIgnoredContent } from "../../discourse/core/strip-ignored-content";
+
+module("Unformatted Code Detector | strip ignored content", function () {
+  test("Unformatted Code Detector | BBCode tags", function (assert) {
+    assert.strictEqual(
+      stripIgnoredContent('[quote="a, post:8, topic:1120"]\nquoted\n[/quote]'),
+      "",
+      "tag with attributes"
+    );
+
+    assert.strictEqual(
+      stripIgnoredContent("[QUOTE]upper[/quote]"),
+      "",
+      "opening and closing tag case do not have to agree"
+    );
+
+    assert.strictEqual(
+      stripIgnoredContent('[quote="a] b"]quoted[/quote]'),
+      "",
+      "attributes containing a closing bracket"
+    );
+
+    assert.strictEqual(
+      stripIgnoredContent("before [quote]quoted[/quote] after"),
+      "before  after",
+      "surrounding text is kept"
+    );
+
+    assert.strictEqual(
+      stripIgnoredContent("unclosed [quote]forever"),
+      "unclosed [quote]forever",
+      "an unclosed tag is not a BBCode tag"
+    );
+  });
+
+  test("Unformatted Code Detector | many unclosed BBCode tags", function (assert) {
+    const content = "[quote]".repeat(3000);
+
+    const start = performance.now();
+    stripIgnoredContent(content);
+    const elapsed = performance.now() - start;
+
+    assert.true(
+      elapsed < 1000,
+      `stripping ${content.length} characters of unclosed tags took ${Math.round(elapsed)}ms, which must stay well under the 1000ms budget`
+    );
+  });
+});


### PR DESCRIPTION
The `.*?` between a BBCode tag's name and its `]` is allowed to give up
its first choice and try every later `]` on the same line, and each of
those retries rescans the whole rest of the post looking for a closing
tag. That makes the cost cubic in the number of `[` markers on a line,
so a single line carrying many unclosed ones takes seconds: around half
a second at 800 markers, three and a half at 1500, half a minute at
3000.

Detection runs synchronously from the composer's save, so this is the
author's own browser frozen when they press Reply. Pasting one long line
of log output or wiki markup is enough to reach it. It is a hang rather
than a vulnerability, since nobody but the author is affected, but it is
still the composer refusing to respond with no explanation.

Restricting the run to characters that cannot end the tag takes the
choice away, and with it the extra factor. What is left is the search
for a closing tag, which is the cost a multi-line paste already had and
is not worth removing.

Nothing about which text gets stripped changes. A lazy quantifier
already stopped at the first `]` whenever a match existed, so only the
failing paths get cheaper. `m` goes at the same time because the pattern
has no anchors for it to affect.

The tag grammar itself is left alone: every paired BBCode tag registered
by core and by the plugins is purely lowercase letters, so `[a-z]+`
already describes it.